### PR TITLE
マイページの作成

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,5 @@
+class MypagesController < ApplicationController
+  def show
+    @articles = current_user.articles
+  end
+end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -5,9 +5,11 @@
       <ul class="navbar-nav">
         <% if user_signed_in?%>
           <li class="nav-item">
-             <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-link active" %>
+            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-link active" %>
           </li>
-
+          <li class="nav-item">
+            <%= link_to "マイページ", mypage_path,class: "nav-link active" %>
+          </li>
           <% else %>
 
           <li class="nav-item">

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,0 +1,30 @@
+<p id="notice"><%= notice %></p>
+
+<h1>マイページ</h1>
+
+ <%= link_to '記事作成', new_article_path, class: "btn btn-info" %>
+
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">タイトル</th>
+      <th scope="col">内容</th>
+
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @articles.each do |article| %>
+      <tr>
+        <td><%= article.title %></td>
+        <td><%= article.content %></td>
+        <td>
+          <%= link_to '詳細', article, class: "btn btn-success" %>
+          <%= link_to '編集', edit_article_path(article),class: "btn btn-warning" %>
+          <%= link_to '削除', article,class: "btn btn-danger", method: :delete, data: { confirm: '削除しますか?' } %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
   root to: 'articles#index'
   resources :articles
   resources :sample_articles
+  resource :mypage
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# 概要
- マイページの作成
# 詳細
- 以下の仕様を満たした マイページ を作成。
  - ログインユーザーに紐づいた記事一覧が閲覧出来る。
  - ログインユーザーに紐づいた記事の作成、編集、削除が出来る。
  - マイページのURLは「/mypage」になるよう設定。
- ヘッダーに「マイページ」へのリンクを設置
  - ログイン状態、ログアウト状態でそれぞれ適切に表示されるよう実装。

# 参考記事
- ログインユーザーに紐づいた記事一覧が閲覧出来る。
   - https://qiita.com/Jumpei_Sogawa/items/f3f2a3866b20028b49e9
- マイページのURLは「/mypage」になるよう設定。
  - https://qiita.com/wacker8818/items/1ba526fcbc73e065a511