### PR TITLE
マイページ周りの修正

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -4,4 +4,5 @@ class MypagesController < ApplicationController
     articles = articles.where(["title LIKE ?","%#{params[:title]}%"]) ,if "%#{params[:title]}%".present?
     @articles = articles.page params[:page]
   end
+ end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,6 @@
    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   </head>
 
   <body>


### PR DESCRIPTION
# 概要
- コードの追記、削除
# 詳細
   - mypages_controllerのend抜けに対する追記。
   - マイページにログインをした際に表示が記事一覧ページと違った為、該当ファイルの記述を削除。