### PR TITLE
記事とタグのアソシエーションの追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,4 +2,6 @@ class Article < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
   belongs_to :user
+  has_many :article_tags,dependent: :destroy
+  has_many :tags, through: :article_tags
 end

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -1,0 +1,4 @@
+class ArticleTag < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,5 @@
 class Tag < ApplicationRecord
   validates :name, presence: true
+  has_many :article_tags,dependent: :destroy
+  has_many :articles,through: :article_tags
 end

--- a/db/migrate/20220627131254_create_article_tags.rb
+++ b/db/migrate/20220627131254_create_article_tags.rb
@@ -1,0 +1,10 @@
+class CreateArticleTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :article_tags do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_23_144015) do
+ActiveRecord::Schema.define(version: 2022_06_27_131254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "article_tags", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_article_tags_on_article_id"
+    t.index ["tag_id"], name: "index_article_tags_on_tag_id"
+  end
 
   create_table "articles", force: :cascade do |t|
     t.string "title", null: false
@@ -42,5 +51,7 @@ ActiveRecord::Schema.define(version: 2022_06_23_144015) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "article_tags", "articles"
+  add_foreign_key "article_tags", "tags"
   add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
# 概要
- 記事とタグの中間テーブルを作成

# 詳細
-  記事とタグが多:多の関係になるようにコードを記述
-  記事とタグの中間テーブルを作成

# 参考記事
- 【Rails】 アソシエーションを図解形式で徹底的に理解しよう！
  - https://pikawaka.com/rails/association
- Ruby on Railsで多対多のテーブル設計を動かしながら理解してみる
   - https://qiita.com/ryutaro9595/items/e021eb789914cead4677